### PR TITLE
[GML] Enable options for aggressive transpose optimizations.

### DIFF
--- a/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
+++ b/compiler/src/iree/compiler/DispatchCreation/Passes.cpp
@@ -80,7 +80,7 @@ static llvm::cl::opt<bool> clEnableAggressiveFusion(
     "iree-dispatch-creation-enable-aggressive-fusion",
     llvm::cl::desc("Aggressive fusion opportunities that are behind a flag "
                    "since all backends dont support it yet"),
-    llvm::cl::init(false));
+    llvm::cl::init(true));
 
 static llvm::cl::opt<bool> clEnableDataTiling(
     "iree-dispatch-creation-experimental-data-tiling",

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -152,7 +152,7 @@ void buildGlobalOptimizationPassPipeline(
       // that operation anyway, and this way we only need to make such a
       // decision once.
       .addPredicatedPass(
-          clEnableTransposePropagation,
+          clEnableTransposePropagation || transformOptions.options.transposePropagation,
           [&]() {
             return createPropagateLinalgTransposePass(
                 transformOptions.options.aggressiveTransposePropagation);

--- a/compiler/src/iree/compiler/Pipelines/Options.h
+++ b/compiler/src/iree/compiler/Pipelines/Options.h
@@ -105,6 +105,9 @@ struct GlobalOptimizationOptions {
   // module.
   std::string parameterSplatExportFile = "";
 
+  // Enables transpose propagation, equivalent to iree-global-opt-propagate-transposes.
+  bool transposePropagation = false;
+
   // Enables aggressive propagation of transposes to the inputs of named ops,
   // rewriting named ops as fused generics.
   bool aggressiveTransposePropagation = false;


### PR DESCRIPTION
This avoids OOM issues in intializers.

Where it wasn't to difficult, I exposed the options, otherwise I changed the defaults.