### PR TITLE
Fix bug in inlineConstantGlobalLoads

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/FoldGlobals.cpp
@@ -243,6 +243,11 @@ static bool inlineConstantGlobalLoads(GlobalTable &globalTable) {
       return GlobalAction::PRESERVE;
     }
 
+    if (!global.loadOps.size()) {
+      // Nothing to inline.
+      return GlobalAction::PRESERVE;
+    }
+
     // Inline initial value into all loads.
     auto inliningPolicy = global.op.getGlobalInliningPolicy();
     SmallVector<IREE::Util::GlobalLoadOpInterface> loadOps = global.loadOps;


### PR DESCRIPTION
Our IR has a global of the form:

```
util.global public @weights.shard0__tensor__a = #flow.parameter.named<"weights.shard0"::"a"> : tensor<2x3x4xf32>
```

which is later referenced by:

```
%0 = flow.tensor.constant #flow.parameter.named<"weights.shard0"::"a"> : tensor<2x3x4xf32>
```

The way it is written, `inlineConstantGlobalLoads` would trigger and since we have no loadOps,
the `if (!global.loadOps.empty() || !global.referencingOps.empty())` check wouldn't fire and the IR would be marked as UPDATED despite there being no change.

This caused the pass to loop and never reach a fixed point. This change fixes said bug.

Signed-off-by: Vihang Mehta <vihang@gimletlabs.ai>
