### PR TITLE
Fallback when workgroup count hints cannot be resolved

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ResolveWorkgroupCountHints.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ResolveWorkgroupCountHints.cpp
@@ -349,8 +349,7 @@ static LogicalResult processHint(IREE::Codegen::WorkgroupCountHintOp hintOp,
   processConditionsFromBase(hintOp, slice.conditions);
   if (failed(getBackwardOrdinalSlice(hintOp, slice.slice, slice.funcArgLeaves,
                                      slice.ordinalLeaves))) {
-    return hintOp->emitOpError(
-        "failed to resolve workgroup count hint in terms of workload ordinals");
+    return failure();
   }
   slice.hintOp = hintOp;
   return success();


### PR DESCRIPTION
Summary: Fall back cleanly when workgroup count hints cannot be resolved to workload ordinals. Avoid emitting a hard compiler diagnostic for cases where the caller can continue without the hint.

Relevant Issues: N/A

type of change: /kind feature

Test plan: Verified this is the same source change previously carried as the Gimlet-side IREE patch.