### PR TITLE
Add include_prefix for compiler plugins

### DIFF
--- a/compiler/plugins/input/StableHLO/Conversion/BUILD.bazel
+++ b/compiler/plugins/input/StableHLO/Conversion/BUILD.bazel
@@ -35,6 +35,7 @@ iree_compiler_cc_library(
         "Passes.h.inc",
         "Rewriters.h",
     ],
+    include_prefix = "iree/compiler/plugins/input/StableHLO/Conversion",
     deps = [
         ":PassesIncGen",
         "@llvm-project//mlir:Pass",
@@ -110,6 +111,7 @@ iree_compiler_cc_library(
     hdrs = [
         "Passes.h",
     ],
+    include_prefix = "iree/compiler/plugins/input/StableHLO/Conversion",
     deps = [
         ":PassHeaders",
         ":StableHLOLegalization",

--- a/compiler/plugins/input/StableHLO/Conversion/Preprocessing/BUILD.bazel
+++ b/compiler/plugins/input/StableHLO/Conversion/Preprocessing/BUILD.bazel
@@ -34,6 +34,7 @@ iree_compiler_cc_library(
         "Passes.h.inc",
         "Rewriters.h",
     ],
+    include_prefix = "iree/compiler/plugins/input/StableHLO/Conversion/Preprocessing",
     deps = [
         ":PassesIncGen",
         "@llvm-project//mlir:Pass",
@@ -75,6 +76,7 @@ iree_compiler_cc_library(
         "Passes.h",
         "Rewriters.h",
     ],
+    include_prefix = "iree/compiler/plugins/input/StableHLO/Conversion/Preprocessing",
     deps = [
         ":ComplexLoweringPatterns",
         ":PassHeaders",

--- a/compiler/plugins/input/TOSA/InputConversion/BUILD.bazel
+++ b/compiler/plugins/input/TOSA/InputConversion/BUILD.bazel
@@ -33,6 +33,7 @@ iree_compiler_cc_library(
         "Passes.h",
         "Passes.h.inc",
     ],
+    include_prefix = "iree/compiler/plugins/input/TOSA/InputConversion",
     deps = [
         ":PassesIncGen",
         "//compiler/src/iree/compiler/Dialect/LinalgExt/IR",
@@ -59,6 +60,7 @@ iree_compiler_cc_library(
     hdrs = [
         "Passes.h",
     ],
+    include_prefix = "iree/compiler/plugins/input/TOSA/InputConversion",
     deps = [
         ":PassHeaders",
         ":PassesIncGen",

--- a/compiler/plugins/input/Torch/InputConversion/BUILD.bazel
+++ b/compiler/plugins/input/Torch/InputConversion/BUILD.bazel
@@ -42,6 +42,7 @@ iree_compiler_cc_library(
         "SetStrictSymbolicShapes.cpp",
     ],
     hdrs = ["Passes.h"],
+    include_prefix = "iree/compiler/plugins/input/Torch/InputConversion",
     deps = [
         ":passes_tblgen_cc_library",
         "//compiler/src/iree/compiler/Dialect/Flow/IR",

--- a/compiler/plugins/target/LLVMCPU/BUILD.bazel
+++ b/compiler/plugins/target/LLVMCPU/BUILD.bazel
@@ -26,6 +26,7 @@ iree_compiler_cc_library(
     hdrs = [
         "LibraryBuilder.h",
     ],
+    include_prefix = "iree/compiler/plugins/target/LLVMCPU",
     deps = [
         ":LLVMIRPasses",
         ":LLVMTargetOptions",
@@ -90,6 +91,7 @@ iree_compiler_cc_library(
     hdrs = [
         "LLVMIRPasses.h",
     ],
+    include_prefix = "iree/compiler/plugins/target/LLVMCPU",
     deps = [
         ":LLVMTargetOptions",
         "@llvm-project//llvm:Analysis",
@@ -112,6 +114,7 @@ iree_compiler_cc_library(
     hdrs = [
         "ResolveCPUAndCPUFeatures.h",
     ],
+    include_prefix = "iree/compiler/plugins/target/LLVMCPU",
     deps = [
         "@llvm-project//llvm:Support",
         "@llvm-project//llvm:Target",
@@ -127,6 +130,7 @@ iree_compiler_cc_library(
     hdrs = [
         "LLVMTargetOptions.h",
     ],
+    include_prefix = "iree/compiler/plugins/target/LLVMCPU",
     deps = [
         ":ResolveCPUAndCPUFeatures",
         "//compiler/src/iree/compiler/Codegen/LLVMCPU",
@@ -147,6 +151,7 @@ iree_compiler_cc_library(
     name = "LinkerTool",
     srcs = ["LinkerTool.cpp"],
     hdrs = ["LinkerTool.h"],
+    include_prefix = "iree/compiler/plugins/target/LLVMCPU",
     deps = platform_trampoline_deps("LinkerTools", "compiler/plugins/target/LLVMCPU") + [
         ":LLVMTargetOptions",
         "//compiler/src/iree/compiler/Utils",
@@ -160,6 +165,7 @@ iree_compiler_cc_library(
 iree_compiler_cc_library(
     name = "LinkerTool_hdrs",
     hdrs = ["LinkerTool.h"],
+    include_prefix = "iree/compiler/plugins/target/LLVMCPU",
     deps = [
         ":LLVMTargetOptions",
         "@llvm-project//llvm:Core",
@@ -177,6 +183,7 @@ iree_compiler_cc_library(
     hdrs = [
         "StaticLibraryGenerator.h",
     ],
+    include_prefix = "iree/compiler/plugins/target/LLVMCPU",
     deps = [
         "@llvm-project//llvm:Support",
     ],

--- a/compiler/plugins/target/LLVMCPU/Builtins/BUILD.bazel
+++ b/compiler/plugins/target/LLVMCPU/Builtins/BUILD.bazel
@@ -24,6 +24,7 @@ iree_compiler_cc_library(
         "Musl.h",
         "UKernel.h",
     ],
+    include_prefix = "iree/compiler/plugins/target/LLVMCPU/Builtins",
     deps = [
         "//compiler/src/iree/compiler/Codegen/Utils",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",

--- a/compiler/plugins/target/MetalSPIRV/BUILD.bazel
+++ b/compiler/plugins/target/MetalSPIRV/BUILD.bazel
@@ -51,6 +51,7 @@ iree_compiler_cc_library(
 iree_compiler_cc_library(
     name = "MetalTargetPlatform",
     hdrs = ["MetalTargetPlatform.h"],
+    include_prefix = "iree/compiler/plugins/target/MetalSPIRV",
 )
 
 iree_compiler_cc_library(
@@ -59,6 +60,7 @@ iree_compiler_cc_library(
         "SPIRVToMSL.cpp",
     ],
     hdrs = ["SPIRVToMSL.h"],
+    include_prefix = "iree/compiler/plugins/target/MetalSPIRV",
     deps = [
         ":MetalTargetPlatform",
         "@llvm-project//llvm:Support",
@@ -73,6 +75,7 @@ iree_compiler_cc_library(
         "MSLToMetalLib.cpp",
     ],
     hdrs = ["MSLToMetalLib.h"],
+    include_prefix = "iree/compiler/plugins/target/MetalSPIRV",
     deps = [
         ":MetalTargetPlatform",
         "@llvm-project//llvm:Support",

--- a/compiler/plugins/target/ROCM/BUILD.bazel
+++ b/compiler/plugins/target/ROCM/BUILD.bazel
@@ -26,6 +26,7 @@ iree_compiler_cc_library(
     hdrs = [
         "ROCMTargetUtils.h",
     ],
+    include_prefix = "iree/compiler/plugins/target/ROCM",
     deps = [
         "//compiler/plugins/target/ROCM/Dialect/ROCM/IR:ROCMDialect",
         "//compiler/plugins/target/ROCM/Dialect/ROCM/Transforms",


### PR DESCRIPTION
This lets us include plugins as `<iree/compiler/plugins/input/Torch/InputConversion/Passes.h>` instead of `"compiler/plugins/input/Torch/InputConversion/Passes.h"`

Signed-off-by: Vihang Mehta <vihang@gimletlabs.ai>
